### PR TITLE
implement cascade selectors

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -1,60 +1,91 @@
 import {kashe, weakKashe, boxed, inboxed, fork} from "../src/weak";
 
 describe('Weak', () => {
-  it('weak memoize', () => {
-    let recomputations = 0;
-    const produce = (state: any, a: any, b: any) => {
-      recomputations++;
-      return {a: a + state.a, b: b + state.b}
-    };
+    it('weak memoize', () => {
+        let recomputations = 0;
+        const produce = (state: any, a: any, b: any) => {
+            recomputations++;
+            return {a: a + state.a, b: b + state.b}
+        };
 
-    const state1 = {a: 1, b: 2};
-    const state2 = {a: 1, b: 2};
+        const state1 = {a: 1, b: 2};
+        const state2 = {a: 1, b: 2};
 
-    // base assertions
+        // base assertions
 
-    expect(produce(state1, 1, 2)).toEqual({a: 2, b: 4});
-    expect(recomputations).toBe(1);
-    expect(produce(state2, 1, 2)).toEqual({a: 2, b: 4});
-    expect(recomputations).toBe(2);
+        expect(produce(state1, 1, 2)).toEqual({a: 2, b: 4});
+        expect(recomputations).toBe(1);
+        expect(produce(state2, 1, 2)).toEqual({a: 2, b: 4});
+        expect(recomputations).toBe(2);
 
 
-    const weakProduce = kashe(produce);
-    const weakResult1 = weakProduce(state1, 1, 2);
+        const weakProduce = kashe(produce);
+        const weakResult1 = weakProduce(state1, 1, 2);
 
-    expect(weakResult1).toEqual({a: 2, b: 4});
-    expect(recomputations).toBe(3);
-    expect(weakResult1).toBe(weakProduce(state1, 1, 2));
-    expect(recomputations).toBe(3);
+        expect(weakResult1).toEqual({a: 2, b: 4});
+        expect(recomputations).toBe(3);
+        expect(weakResult1).toBe(weakProduce(state1, 1, 2));
+        expect(recomputations).toBe(3);
 
-    const weakResult1_2 = weakProduce(state1, 2, 2);
-    expect(recomputations).toBe(4);
-    expect(weakResult1_2).toEqual({a: 3, b: 4});
-    const weakResult2 = weakProduce(state2, 1, 2);
+        const weakResult1_2 = weakProduce(state1, 2, 2);
+        expect(recomputations).toBe(4);
+        expect(weakResult1_2).toEqual({a: 3, b: 4});
+        const weakResult2 = weakProduce(state2, 1, 2);
 
-    expect(weakResult2).toBe(weakProduce(state2, 1, 2));
-    expect(weakResult1_2).toBe(weakProduce(state1, 2, 2));
-  });
+        expect(weakResult2).toBe(weakProduce(state2, 1, 2));
+        expect(weakResult1_2).toBe(weakProduce(state1, 2, 2));
+    });
 
-  it('weak kashe', () => {
-    const kasheMap = kashe((data: any[], iterator: (x: number) => number) => data.map(i => iterator(i)));
-    const weakMap = weakKashe((data: any[], iterator: (x: number) => number) => data.map(i => iterator(i)));
+    it('weak kashe', () => {
+        const kasheMap = kashe((data: any[], iterator: (x: number) => number) => data.map(i => iterator(i)));
+        const weakMap = weakKashe((data: any[], iterator: (x: number) => number) => data.map(i => iterator(i)));
 
-    const map = (x: number) => x + 1;
-    const data = [0, 1];
+        const map = (x: number) => x + 1;
+        const data = [0, 1];
 
-    expect(kasheMap(data, map)).toBe(kasheMap(data, map));
-    expect(weakMap(data, map)).toBe(weakMap(data, map));
+        expect(kasheMap(data, map)).toBe(kasheMap(data, map));
+        expect(weakMap(data, map)).toBe(weakMap(data, map));
 
-    expect(kasheMap(data, x => x + 1)).not.toBe(kasheMap(data, x => x + 1));
-    expect(weakMap(data, x => x + 1)).toBe(weakMap(data, x => x + 1));
-    expect(weakMap(data, x => x + 1, 1)).toBe(weakMap(data, x => x + 1, 1));
-    expect(weakMap(data, x => x + 1, 1)).not.toBe(weakMap(data, x => x + 1, 2));
-    //
-    expect(weakMap(data, x => x + 1)).toEqual([1, 2]);
-  });
+        expect(kasheMap(data, x => x + 1)).not.toBe(kasheMap(data, x => x + 1));
+        expect(weakMap(data, x => x + 1)).toBe(weakMap(data, x => x + 1));
+        // @ts-ignore
+        expect(weakMap(data, x => x + 1, 1)).toBe(weakMap(data, x => x + 1, 1));
+        // @ts-ignore
+        expect(weakMap(data, x => x + 1, 1)).not.toBe(weakMap(data, x => x + 1, 2));
+        //
+        expect(weakMap(data, x => x + 1)).toEqual([1, 2]);
+    });
 
-  describe('nested memoization', () => {
+    it('cascade memoization', () => {
+        const test = kashe((x: any, y: any, z: any) => ({x, y, z}));
+        const arg1 = {arg1:1};
+        const arg3_1 = {arg3_1:1};
+        const arg3_2 = {arg3_2:1};
+        {
+            const result1 = test(arg1, 1, arg3_1);
+            const result2 = test(arg1, 2, arg3_1);
+            // arg2 bypassed cache
+            expect(result1).not.toBe(test(arg1, 1, arg3_1));
+            expect(result2).not.toBe(test(arg1, 2, arg3_1));
+        }
+        {
+            const result1 = test(arg1, arg3_1, 1);
+            const result2 = test(arg1, arg3_2, 2);
+            // result is saved in arg3
+            expect(result1).toBe(test(arg1, arg3_1, 1));
+            expect(result2).toBe(test(arg1, arg3_2, 2));
+        }
+        {
+            const result1 = test(arg1, 1, arg3_1);
+            const result2 = test(arg1, 2, arg3_2);
+            // arg2 bypassed cache
+            expect(result1).toBe(test(arg1, 1, arg3_1));
+            expect(result2).toBe(test(arg1, 2, arg3_2));
+        }
+    });
+})
+
+describe('nested memoization', () => {
     const data1 = {data: 1};
     const data2 = {data: 2};
     const state1 = {state: 1};
@@ -64,81 +95,80 @@ describe('Weak', () => {
     const fn1 = kashe(produce);
 
     it('smoke check', () => {
-      const r1 = fn1(data1);
-      fn1(data2);
-      expect(r1).toBe(fn1(data1));
+        const r1 = fn1(data1);
+        fn1(data2);
+        expect(r1).toBe(fn1(data1));
     });
 
     const boxedFn = boxed(fn1);
 
     it('boxed check', () => {
-      const r1 = boxedFn(state1, data1);
-      const r2 = boxedFn(state2, data1);
-      const r3 = boxedFn(state1, data2);
+        const r1 = boxedFn(state1, data1);
+        const r2 = boxedFn(state2, data1);
+        const r3 = boxedFn(state1, data2);
 
-      expect(r1).toBe(r2);
-      expect(r3).toBe(boxedFn(state1, data2));
-      expect(r1).toBe(boxedFn(state1, data1));
-      expect(r1).toBe(boxedFn(state2, data1));
+        expect(r1).toBe(r2);
+        expect(r3).toBe(boxedFn(state1, data2));
+        expect(r1).toBe(boxedFn(state1, data1));
+        expect(r1).toBe(boxedFn(state2, data1));
     });
 
     const inboxedFn = inboxed(fn1);
 
     it('inboxed check', () => {
-      const r1 = inboxedFn(state1, data1);
-      const m1 = inboxedFn(state1, data1);
-      expect(r1).toBe(m1);
+        const r1 = inboxedFn(state1, data1);
+        const m1 = inboxedFn(state1, data1);
+        expect(r1).toBe(m1);
 
-      const r2 = inboxedFn(state2, data1);
-      const r3 = inboxedFn(state1, data2);
-      const m3 = inboxedFn(state1, data2);
-      const z1 = inboxedFn(state1, data1);
+        const r2 = inboxedFn(state2, data1);
+        const r3 = inboxedFn(state1, data2);
+        const m3 = inboxedFn(state1, data2);
+        const z1 = inboxedFn(state1, data1);
 
-      expect(r1).not.toBe(r2);
-      expect(r1).not.toBe(r3);
-      expect(r3).toBe(m3);
-      expect(r1).toBe(z1);
+        expect(r1).not.toBe(r2);
+        expect(r1).not.toBe(r3);
+        expect(r3).toBe(m3);
+        expect(r1).toBe(z1);
     });
 
     it('inboxed nested', () => {
-      let cnt = 0;
-      const fn1 = () => cnt++;
-      const fn2 = () => cnt++;
-      const kfn1 = kashe(fn1);
-      const kfn2 = kashe(fn2);
+        let cnt = 0;
+        const fn1 = () => cnt++;
+        const fn2 = () => cnt++;
+        const kfn1 = kashe(fn1);
+        const kfn2 = kashe(fn2);
 
-      const obj = {};
+        const obj = {};
 
-      const v1 = kfn1(obj);
-      const v2 = kfn2(obj);
+        const v1 = kfn1(obj);
+        const v2 = kfn2(obj);
 
-      expect(v1).toBe(kfn1(obj));
-      expect(v2).toBe(kfn2(obj));
-      expect(v1).not.toBe(v2);
+        expect(v1).toBe(kfn1(obj));
+        expect(v2).toBe(kfn2(obj));
+        expect(v1).not.toBe(v2);
 
-      const ifn = inboxed((st) => [kfn1(st), kfn2(st)]);
+        const ifn = inboxed((st) => [kfn1(st), kfn2(st)]);
 
-      expect(ifn(obj, obj)).toEqual([2, 3]);
-      expect(ifn(obj, obj)).toEqual([2, 3]);
+        expect(ifn(obj, obj)).toEqual([2, 3]);
+        expect(ifn(obj, obj)).toEqual([2, 3]);
     });
     const forkedFn1 = fork(fn1);
     const forkedFn2 = fork(fn1);
 
     it('fork check', () => {
-      const r1 = forkedFn1(data1);
-      const m1 = forkedFn1(data1);
-      expect(r1).toBe(m1);
+        const r1 = forkedFn1(data1);
+        const m1 = forkedFn1(data1);
+        expect(r1).toBe(m1);
 
-      const r2 = forkedFn2(data1);
-      const r3 = forkedFn1(data2);
-      const m3 = forkedFn1(data2);
-      const z1 = forkedFn1(data1);
+        const r2 = forkedFn2(data1);
+        const r3 = forkedFn1(data2);
+        const m3 = forkedFn1(data2);
+        const z1 = forkedFn1(data1);
 
-      expect(r1).not.toBe(r2);
-      expect(r1).not.toBe(r3);
-      expect(r3).toBe(m3);
-      expect(r1).toBe(z1);
+        expect(r1).not.toBe(r2);
+        expect(r1).not.toBe(r3);
+        expect(r3).toBe(m3);
+        expect(r1).toBe(z1);
     });
 
-  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface WeakResult {
   value: any;
-  index: number;
+  // index: number;
 }
 
 export interface WeakStorage {
@@ -9,8 +9,8 @@ export interface WeakStorage {
   set(args: any[], value: any): any;
 }
 
-export interface WeakMappable {
-  get(key: any): any | undefined;
+export interface WeakMappable<T = any> {
+  get(key: any): T | undefined;
 
-  set(set: any, value: any): void;
+  set(set: any, value: T): void;
 }

--- a/src/weakStorage.ts
+++ b/src/weakStorage.ts
@@ -1,36 +1,93 @@
 import {WeakMappable, WeakStorage} from "./types";
 import {isWeakable} from "./utils";
 
-export const createWeakStorage = (indexId = 0, storage: WeakMappable = new WeakMap()): WeakStorage => ({
-  get(args) {
-    if (!isWeakable(args[indexId])) {
-      console.log('arguments given', args);
-      throw new Error(`Argument #${indexId} expected to be weak-mappable object, ${typeof args[indexId]} given`);
+export const breakdownArgs = (args: any[]) => {
+    let saveSlice = [];
+    for (let i = 0; i < args.length; i++) {
+        if (isWeakable(args[i])) {
+            saveSlice.push(args[i]);
+        }
     }
-    const test = storage.get(args[indexId]);
-    if (test) {
-      const a = test.arguments;
-      if (a.length === args.length) {
+    return saveSlice;
+}
+
+type Test = {
+    arguments?: any[];
+    storedValue?: any;
+    storage?: WeakMappable<Test>;
+}
+
+const testArgs = (test: Test, args: any[]) => {
+    const a = test.arguments;
+    if (!a) {
+        return undefined;
+    }
+    if (a.length === args.length) {
         for (let i = 0; i < a.length; ++i) {
-          if (a[i] !== args[i]) {
-            return undefined;
-          }
+            if (a[i] !== args[i]) {
+                return undefined;
+            }
         }
-        return {
-          value: test.storedValue,
-          index: indexId,
-        }
-      }
+        return test;
     }
-
     return undefined;
-  },
+}
 
-  set(args, value) {
-    storage.set(args[indexId], {
-      storedValue: value,
-      arguments: args,
-    });
-    return value;
-  },
+export const createWeakStorage = (storage: WeakMappable<Test> = new WeakMap()): WeakStorage => ({
+    get(args) {
+        const slices = breakdownArgs(args);
+        if (!slices.length) {
+            throw new Error(`No weak-mappable (object, function, symbol) arguments found.`);
+        }
+        let readFrom = storage;
+        console.log('get breakdown', slices);
+        for (let i = 0; i < slices.length; ++i) {
+            const test = readFrom.get(slices[i]);
+            if (!test || !test.storage) {
+                console.log('get: no forward');
+                return undefined
+            }
+            readFrom = test.storage;
+        }
+        if (!readFrom) {
+            return undefined;
+        }
+        const test = readFrom.get(slices[0]);
+        if (test) {
+            const storedValue = testArgs(test, args);
+            if (storedValue) {
+                return {
+                    value: test.storedValue,
+                }
+            } else {
+                console.log('get: arg mismatch');
+            }
+        } else {
+            console.log('get: no key');
+        }
+
+        return undefined;
+    },
+
+    set(args, value) {
+        const slices = breakdownArgs(args);
+        console.log('set breakdown', slices);
+        let writeTo = storage;
+        for (let i = 0; i < slices.length; ++i) {
+            let next = writeTo.get(slices[i]);
+            if (!next || !next.storage) {
+                next = {
+                    storage: new WeakMap()
+                };
+                writeTo.set(slices[i], next);
+            }
+            writeTo = next.storage!;
+        }
+        writeTo.set(slices[0], {
+            storedValue: value,
+            arguments: args,
+            storage: undefined
+        });
+        return value;
+    },
 });


### PR DESCRIPTION
Inspired by:
- https://github.com/facebook/react/blob/0b974418c9a56f6c560298560265dcf4b65784bc/packages/react/src/ReactCache.js
- https://github.com/reduxjs/reselect/releases

Implements cascade cache for every weak-mappable object passed in. This should improve cache retention and hit-rates for multi-argument use cases.