### PR TITLE
feat: introduce strong storage tail

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -64,21 +64,21 @@ describe('Weak', () => {
         {
             const result1 = test(arg1, 1, arg3_1);
             const result2 = test(arg1, 2, arg3_1);
-            // arg2 bypassed cache
-            expect(result1).not.toBe(test(arg1, 1, arg3_1));
-            expect(result2).not.toBe(test(arg1, 2, arg3_1));
+            // arg2 stored in v3 position
+            expect(result1).toBe(test(arg1, 1, arg3_1));
+            expect(result2).toBe(test(arg1, 2, arg3_1));
         }
         {
             const result1 = test(arg1, arg3_1, 1);
             const result2 = test(arg1, arg3_2, 2);
-            // result is saved in arg3
+            // result is saved in save v3 position
             expect(result1).toBe(test(arg1, arg3_1, 1));
             expect(result2).toBe(test(arg1, arg3_2, 2));
         }
         {
             const result1 = test(arg1, 1, arg3_1);
             const result2 = test(arg1, 2, arg3_2);
-            // arg2 bypassed cache
+            // arg3 bypassed cache
             expect(result1).toBe(test(arg1, 1, arg3_1));
             expect(result2).toBe(test(arg1, 2, arg3_2));
         }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   ],
   "dependencies": {
     "function-double": "^1.0.4",
-    "reselect": "^4.0.0"
+    "reselect": "^4.0.0",
+    "tslib": "^2.6.2"
   }
 }

--- a/src/strongStorage.ts
+++ b/src/strongStorage.ts
@@ -1,7 +1,7 @@
-import {WeakMappable, WeakStorage} from "./types";
+import {Mappable, WeakStorage} from "./types";
 import {isWeakable} from "./utils";
 
-export const createStrongStorage = (startIndex = 0, endIndex = Infinity, storage: WeakMappable = new WeakMap()): WeakStorage => ({
+export const createStrongStorage = (startIndex = 0, endIndex = Infinity, storage: Mappable = new WeakMap()): WeakStorage => ({
   get(args) {
     const max = Math.min(endIndex, args.length);
     let reads = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface WeakStorage {
   set(args: any[], value: any): any;
 }
 
-export interface WeakMappable<T = any> {
+export interface Mappable<T = any> {
   get(key: any): T | undefined;
 
   set(set: any, value: T): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10870,6 +10870,11 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslint-config-prettier@^1.10.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"


### PR DESCRIPTION
After this change cache creator will split arguments to `weak` and `strong`, storing `strongs` not in a single `arguments` but in a nested Map structure

Nothing changes from data retaining point of view, except it now can store more data

At least one weakmappable argument is still a hard requirement.